### PR TITLE
Correct the usage of `initial-scratch-message`

### DIFF
--- a/scratch-ext.el
+++ b/scratch-ext.el
@@ -99,7 +99,7 @@ If nil, scratch buffer is not saved."
   "Return non-nil if the *scratch* buffer is not to be saved.
 TEXT is contents of the *scratch* buffer."
   (or (string-match-p scratch-ext-text-ignore-regexp text)
-      (string= text (or initial-scratch-message ""))))
+      (string= text (or (substitute-command-keys initial-scratch-message) ""))))
 
 (defun scratch-ext--clear-scratch ()
   "Clear the *scratch* buffer."
@@ -112,7 +112,7 @@ TEXT is contents of the *scratch* buffer."
     (funcall initial-major-mode)
     (erase-buffer)
     (when initial-scratch-message
-      (insert initial-scratch-message))))
+      (insert (substitute-command-keys initial-scratch-message)))))
 
 (defun scratch-ext-kill-buffer-query-function ()
   "If the current buffer is the *scratch* buffer, save and clear it."


### PR DESCRIPTION
Hi! Thanks for your useful library. I do like such a unobtrusive tool.

I've used `scratch-ext.el` some recent years but I found out two weird behavior:

1. My `~/.emacs/scratch/` contains over 1,200 files (145 bytes) that are identical to each other.
2. The content of the `*scratch*` buffer changes immediately after `C-x k`  (`kill-buffer`), even if the content remains as the initial.

I also found the source of them. I think the variable `initial-scratch-message` should be used after the application of `(substitute-command-keys)` as [Emacs itself does](https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/startup.el?h=emacs-29.4#n2791).

I have no (waste) duplicated files, and `*scratch*` remain the same content with this fix.

Some footnotes:

* This substitution was effective since [9 years ago](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=3d08d06a661344c0ff645e6362e2a2fe1f2e7348) because of `\\[find-file]`.
* The function `(substitute-command-keys)` is [nil-safe](https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/help.el?h=emacs-29.4#n1310); it returns `nil` when `nil` given as its argument, so we can keep the codes simple.
* There will be no compatibility issues with this function dependency since it was mentioned as old as [37 years ago](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=b20cd8dbd051aa561257df965c0d3eaef5df069e) 😲